### PR TITLE
Remove unneeded dependency

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -31,7 +31,6 @@ cc_binary {
         "libbase",
         "libvisclient",
         "libhidlbase",
-        "libhidltransport",
         "liblog",
         "libutils",
         "android.hardware.automotive.vehicle@2.0",


### PR DESCRIPTION
libhidltransport is not needed for vehicle HAL.

Signed-off-by: Andrii Chepurnyi <andrii_chepurnyi@epam.com>